### PR TITLE
Change jstl library to fix security vulnerabilities

### DIFF
--- a/java/server-dependencies/pom.xml
+++ b/java/server-dependencies/pom.xml
@@ -80,8 +80,8 @@
 
     <!-- external dependencies -->
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>jstl</artifactId>
+      <groupId>org.apache.taglibs</groupId>
+      <artifactId>taglibs-standard-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1779,9 +1779,9 @@
         <version>1.7.7</version>
       </dependency>
       <dependency>
-        <groupId>javax.servlet</groupId>
-        <artifactId>jstl</artifactId>
-        <version>1.2</version>
+        <groupId>org.apache.taglibs</groupId>
+        <artifactId>taglibs-standard-impl</artifactId>
+        <version>1.2.5</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Apache Standard Taglibs before 1.2.3 allows remote attackers to execute arbitrary code or conduct external XML entity (XXE) attacks via a crafted XSLT extension in a (1) <x:parse> or (2) <x:transform> JSTL XML tag.
CVE-2015-0254

This is fixed by updating the jstl version.