### PR TITLE
Add filter to detect unauthorized host names

### DIFF
--- a/java/common/pom.xml
+++ b/java/common/pom.xml
@@ -61,6 +61,16 @@
         </includes>
       </resource>
     </resources>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 
   <profiles>

--- a/java/common/src/main/java/org/apache/shindig/common/servlet/MultiReadHttpServletRequest.java
+++ b/java/common/src/main/java/org/apache/shindig/common/servlet/MultiReadHttpServletRequest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.shindig.common.servlet;
+
+import org.apache.commons.io.IOUtils;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import javax.servlet.ServletInputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+
+/**
+ * Wrapper class for the HttpServletRequest, that enables reading the request data input stream more than once.
+ */
+public class MultiReadHttpServletRequest extends HttpServletRequestWrapper {
+
+    private ByteArrayOutputStream cachedBytes;
+
+    public MultiReadHttpServletRequest(HttpServletRequest request) {
+        super(request);
+    }
+
+    @Override
+    public ServletInputStream getInputStream() throws IOException {
+
+        if (cachedBytes == null) {
+            cacheInputStream();
+        }
+
+        return new CachedServletInputStream();
+    }
+
+    @Override
+    public BufferedReader getReader() throws IOException {
+
+        return new BufferedReader(new InputStreamReader(getInputStream()));
+    }
+
+    /**
+     * Cache the input stream in order to read it multiple times.
+     *
+     * @throws IOException
+     */
+    private void cacheInputStream() throws IOException {
+
+        cachedBytes = new ByteArrayOutputStream();
+        IOUtils.copy(super.getInputStream(), cachedBytes);
+    }
+
+    /**
+     * An input stream which reads the cached request body.
+     */
+    public class CachedServletInputStream extends ServletInputStream {
+
+        private ByteArrayInputStream input;
+
+        /**
+         * Create a new input stream from the cached request body.
+         */
+        public CachedServletInputStream() {
+
+            input = new ByteArrayInputStream(cachedBytes.toByteArray());
+        }
+
+        @Override
+        public int read() {
+            return input.read();
+        }
+    }
+}

--- a/java/common/src/main/java/org/apache/shindig/common/servlet/URLFilter.java
+++ b/java/common/src/main/java/org/apache/shindig/common/servlet/URLFilter.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.shindig.common.servlet;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * A filter that checks for external URLs in shindig request parameters.
+ */
+public class URLFilter implements Filter {
+
+    private static final String URL_REGEX = "https?://[-a-zA-Z0-9+&@#%?=~_|!:,.;]*";
+    private static final String ALLOWED_HOST_NAMES_PARAM = "allowedHostNames";
+    private static Logger log = Logger.getLogger(URLFilter.class.getName());
+
+    private List<String> allowedHostNames;
+
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+
+        if (httpRequest.getMethod().equalsIgnoreCase("POST")) {
+
+            // MultiReadHttpServletRequest is used to read request data more than once.
+            MultiReadHttpServletRequest multiReadRequest = new MultiReadHttpServletRequest(httpRequest);
+
+            if (handlePOSTRequest(multiReadRequest)) {
+                chain.doFilter(multiReadRequest, response);
+            } else {
+                HttpServletResponse httpResponse = (HttpServletResponse) response;
+                httpResponse.sendError(HttpServletResponse.SC_FORBIDDEN, "Unauthorized body parameter detected!");
+            }
+
+        } else if (httpRequest.getMethod().equalsIgnoreCase("GET")) {
+
+            if (!isInvalidHostNamePresent(URLDecoder.decode(httpRequest.getQueryString(),
+                    StandardCharsets.UTF_8.name()))) {
+                chain.doFilter(httpRequest, response);
+            } else {
+                HttpServletResponse httpResponse = (HttpServletResponse) response;
+                httpResponse.sendError(HttpServletResponse.SC_FORBIDDEN, "Unauthorized query parameter detected!");
+            }
+        }
+    }
+
+    private boolean handlePOSTRequest(MultiReadHttpServletRequest multiReadRequest) throws ServletException {
+
+        StringBuilder stringBuffer = new StringBuilder();
+        String line;
+        try {
+            BufferedReader reader = multiReadRequest.getReader();
+            while ((line = reader.readLine()) != null) {
+                stringBuffer.append(line);
+            }
+        } catch (IOException e) {
+            throw new ServletException("Error occurred while reading request body in shindig URL filter.", e);
+        }
+
+        return !isInvalidHostNamePresent(stringBuffer.toString());
+    }
+
+    private boolean isInvalidHostNamePresent(String text) throws ServletException {
+
+        Pattern pattern = Pattern.compile(URL_REGEX);
+        Matcher matcher = pattern.matcher(text);
+
+        while (matcher.find()) {
+            String match = matcher.group();
+            try {
+                URI uri = new URI(match);
+                if (uri.getHost() != null && !allowedHostNames.contains(uri.getHost())) {
+                    log.warning("Potential External Service Interaction (DNS) attack thwarted. Unauthorized " +
+                            "host name: " + uri.getHost() + " detected in shindig web app request parameters.");
+                    return true;
+                }
+            } catch (URISyntaxException e) {
+                throw new ServletException("Error occurred while validating request parameters in shindig " +
+                        "URL filter.", e);
+            }
+        }
+        return false;
+    }
+
+    public void destroy() {
+    }
+
+    public void init(FilterConfig filterConfig) {
+
+        String allowedHostNamesString = filterConfig.getInitParameter(ALLOWED_HOST_NAMES_PARAM);
+        allowedHostNamesString += ", " + System.getProperty(ALLOWED_HOST_NAMES_PARAM);
+        allowedHostNames = Arrays.asList(allowedHostNamesString.trim().split("\\s*,\\s*"));
+    }
+}

--- a/java/server-resources/src/main/webapp/WEB-INF/web.xml
+++ b/java/server-resources/src/main/webapp/WEB-INF/web.xml
@@ -159,6 +159,19 @@
     <url-pattern>*</url-pattern>
   </filter-mapping>
 
+  <filter>
+    <filter-name>URLFilter</filter-name>
+    <filter-class>org.apache.shindig.common.servlet.URLFilter</filter-class>
+    <init-param>
+      <param-name>allowedHostNames</param-name>
+      <param-value>localhost, 127.0.0.1</param-value>
+    </init-param>
+  </filter>
+  <filter-mapping>
+    <filter-name>URLFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+
   <listener>
     <listener-class>org.apache.shindig.common.servlet.GuiceServletContextListener</listener-class>
   </listener>


### PR DESCRIPTION
### Proposed changes.
- Added a new filter applied to all request go through shindig web app. This filter validates any host names comes in query parameters and body parameters, against a given list of allowed host names. Allowed host names can be defined as follows.
```
    <init-param>
      <param-name>allowedHostNames</param-name>
      <param-value>localhost, 127.0.0.1</param-value>
    </init-param>
```