### PR TITLE
Remove use of StandardCharsets

### DIFF
--- a/java/common/pom.xml
+++ b/java/common/pom.xml
@@ -61,16 +61,6 @@
         </includes>
       </resource>
     </resources>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
-    </plugins>
   </build>
 
   <profiles>

--- a/java/common/src/main/java/org/apache/shindig/common/servlet/URLFilter.java
+++ b/java/common/src/main/java/org/apache/shindig/common/servlet/URLFilter.java
@@ -23,8 +23,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Logger;
@@ -69,8 +67,7 @@ public class URLFilter implements Filter {
 
         } else if (httpRequest.getMethod().equalsIgnoreCase("GET")) {
 
-            if (!isInvalidHostNamePresent(URLDecoder.decode(httpRequest.getQueryString(),
-                    StandardCharsets.UTF_8.name()))) {
+            if (!isInvalidHostNamePresent(URLDecoder.decode(httpRequest.getQueryString(), "UTF-8"))) {
                 chain.doFilter(httpRequest, response);
             } else {
                 HttpServletResponse httpResponse = (HttpServletResponse) response;


### PR DESCRIPTION
### Proposed changes
- To use StandardCharsets, a build plugin has to be included and this caused build failures in different environments.