### PR TITLE
Add support to read carbon hostname for URL filtering

### DIFF
--- a/java/common/pom.xml
+++ b/java/common/pom.xml
@@ -83,6 +83,20 @@
   <dependencies>
     <!-- external dependencies -->
     <dependency>
+      <groupId>org.wso2.carbon</groupId>
+      <artifactId>org.wso2.carbon.utils</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.eclipse.equinox</groupId>
+          <artifactId>javax.servlet</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>xerces.wso2</groupId>
+          <artifactId>xercesImpl</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
     </dependency>
@@ -149,5 +163,6 @@
       <artifactId>slf4j-jdk14</artifactId>
       <scope>test</scope>
     </dependency>
+
   </dependencies>
 </project>

--- a/java/common/src/main/java/org/apache/shindig/common/servlet/URLFilter.java
+++ b/java/common/src/main/java/org/apache/shindig/common/servlet/URLFilter.java
@@ -18,6 +18,9 @@
 
 package org.apache.shindig.common.servlet;
 
+import org.wso2.carbon.base.ServerConfiguration;
+import org.wso2.carbon.utils.CarbonUtils;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.net.URI;
@@ -119,8 +122,26 @@ public class URLFilter implements Filter {
 
     public void init(FilterConfig filterConfig) {
 
-        String allowedHostNamesString = filterConfig.getInitParameter(ALLOWED_HOST_NAMES_PARAM);
-        allowedHostNamesString += ", " + System.getProperty(ALLOWED_HOST_NAMES_PARAM);
-        allowedHostNames = Arrays.asList(allowedHostNamesString.trim().split("\\s*,\\s*"));
+        ServerConfiguration serverConfig = CarbonUtils.getServerConfiguration();
+
+        StringBuffer allowedHostNamesBuffer = new StringBuffer();
+        // Reading hostname from carbon.xml file.
+        appendParam(allowedHostNamesBuffer, serverConfig.getFirstProperty("HostName"));
+        // Reading allowed host names passed as filter init params.
+        appendParam(allowedHostNamesBuffer, filterConfig.getInitParameter(ALLOWED_HOST_NAMES_PARAM));
+        // Reading allowed host names passed as JVM system properties.
+        appendParam(allowedHostNamesBuffer, System.getProperty(ALLOWED_HOST_NAMES_PARAM));
+
+        allowedHostNames = Arrays.asList(allowedHostNamesBuffer.toString().trim().split("\\s*,\\s*"));
+    }
+
+    private void appendParam(StringBuffer buffer, String param) {
+
+        if (param != null) {
+            if (buffer.length() > 0) {
+                buffer.append(", ");
+            }
+            buffer.append(param);
+        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
     <shindig.jdk.javadoc>1.6.0</shindig.jdk.javadoc>
     <shindig.jdk.classifier />
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <carbon.kernel.version>4.4.11</carbon.kernel.version>
   </properties>
 
   <prerequisites>
@@ -1498,6 +1499,11 @@
   <dependencyManagement>
     <dependencies>
       <!-- project dependencies -->
+      <dependency>
+        <groupId>org.wso2.carbon</groupId>
+        <artifactId>org.wso2.carbon.utils</artifactId>
+        <version>${carbon.kernel.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.wso2.org.apache.shindig</groupId>
         <artifactId>shindig-features</artifactId>


### PR DESCRIPTION
### Proposed changes.
The URL filter introduced in https://github.com/wso2/wso2-shindig/pull/8, can now use the hostname defined in the carbon.xml file to filter unauthorized host names.