### PR TITLE
Update URL_REGEX to filter hostname from url query params

### DIFF
--- a/java/common/src/main/java/org/apache/shindig/common/servlet/URLFilter.java
+++ b/java/common/src/main/java/org/apache/shindig/common/servlet/URLFilter.java
@@ -45,7 +45,7 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class URLFilter implements Filter {
 
-    private static final String URL_REGEX = "https?://[-a-zA-Z0-9+&@#%?=~_|!:,.;]*";
+    private static final String URL_REGEX = "https?://[-a-zA-Z0-9+@#%?=~_|!:,.;]*";
     private static final String ALLOWED_HOST_NAMES_PARAM = "allowedHostNames";
     private static final String ENABLE_FILTER_PARAM = "enable";
     private static Logger log = Logger.getLogger(URLFilter.class.getName());
@@ -73,7 +73,7 @@ public class URLFilter implements Filter {
 
             } else if (httpRequest.getMethod().equalsIgnoreCase("GET")) {
 
-                if (!isInvalidHostNamePresent(URLDecoder.decode(httpRequest.getQueryString(), "UTF-8"))) {
+                if (httpRequest.getQueryString() != null && !isInvalidHostNamePresent(URLDecoder.decode(httpRequest.getQueryString(), "UTF-8"))) {
                     chain.doFilter(httpRequest, response);
                 } else {
                     HttpServletResponse httpResponse = (HttpServletResponse) response;

--- a/java/server-resources/src/main/webapp/WEB-INF/web.xml
+++ b/java/server-resources/src/main/webapp/WEB-INF/web.xml
@@ -166,6 +166,10 @@
       <param-name>allowedHostNames</param-name>
       <param-value>localhost, 127.0.0.1</param-value>
     </init-param>
+    <init-param>
+      <param-name>enable</param-name>
+      <param-value>false</param-value>
+    </init-param>
   </filter>
   <filter-mapping>
     <filter-name>URLFilter</filter-name>


### PR DESCRIPTION
**Proposed changes**
Update the URL_REGEX to filter the hostnames from the "url" query params of shindig endpoint and do the null check to check whether the particular request has query params or not.