### PR TITLE
Remove dependency for wso2-extensions module

### DIFF
--- a/java/server-dependencies/pom.xml
+++ b/java/server-dependencies/pom.xml
@@ -77,12 +77,6 @@
       <classifier>${shindig.jdk.classifier}</classifier>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.wso2.org.apache.shindig</groupId>
-      <artifactId>wso2-extensions</artifactId>
-      <classifier>${shindig.jdk.classifier}</classifier>
-      <version>${project.version}</version>
-    </dependency>
 
     <!-- external dependencies -->
     <dependency>


### PR DESCRIPTION
- This is to fix the unit test failures occurred with https://github.com/wso2/wso2-shindig/pull/15
- Earlier, we packed the wso2-extensions JAR with shindig which causes the test failures. Now we only push the JAR to nexus and repack it in product-is.