### PR TITLE
Update dependency versions 

### DIFF
--- a/java/gadgets/pom.xml
+++ b/java/gadgets/pom.xml
@@ -239,6 +239,17 @@
       <groupId>com.google.javascript</groupId>
       <artifactId>closure-compiler</artifactId>
       <version>v20131014</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>3.21.12</version>
     </dependency>
 
     <!-- test -->

--- a/pom.xml
+++ b/pom.xml
@@ -1662,7 +1662,7 @@
       <dependency>
         <artifactId>commons-collections</artifactId>
         <groupId>commons-collections</groupId>
-        <version>3.2.1</version>
+        <version>3.2.2</version>
       </dependency>
       <dependency>
         <groupId>diff_match_patch</groupId>
@@ -1698,7 +1698,7 @@
       <dependency>
         <groupId>net.sourceforge.htmlunit</groupId>
         <artifactId>htmlunit</artifactId>
-        <version>2.15</version>
+        <version>2.19</version>
       </dependency>
       <dependency>
         <groupId>log4j</groupId>
@@ -1723,7 +1723,7 @@
       <dependency>
         <groupId>com.thoughtworks.xstream</groupId>
         <artifactId>xstream</artifactId>
-        <version>1.4.11.1</version>
+        <version>1.4.20</version>
       </dependency>
       <dependency>
         <groupId>xpp3</groupId>
@@ -1774,12 +1774,12 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.3.6</version>
+        <version>4.5.14</version>
       </dependency>
       <dependency>
         <groupId>org.apache.shiro</groupId>
         <artifactId>shiro-web</artifactId>
-        <version>1.2.6</version>
+        <version>1.10.1</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
This PR will update the following dependencies
- com.google.protobuf: protobuf-java to `3.21.12`
- commons-collections: ommons-collections to `3.2.2`
- net.sourceforge.htmlunit: htmlunit to `2.19`
- com.thoughtworks.xstream: xstream to `1.4.20`
- org.apache.httpcomponents: httpclient to `4.5.14`
- org.apache.shiro: shiro-web: to `1.10.1`